### PR TITLE
Use AVSpeechSynthesizer on Mac. Closes #1

### DIFF
--- a/macspeech.lua
+++ b/macspeech.lua
@@ -1,19 +1,21 @@
+local objc = require("objc.objc")
 
-objc=require "objc/objc"
-local synth=objc.NSSpeechSynthesizer:alloc():init()
-local function output(text)
-    if type(text) ~="string" then
-        text=tostring(text)
-    end
-    synth:startSpeakingString(text)
+objc.load("AVFoundation")
+local backend = {}
+backend.synth = objc.AVSpeechSynthesizer:alloc():init()
+
+function backend.output(text, interrupt)
+	text = tostring(text)
+	interrupt = interrupt or false
+	if interrupt then
+		backend.synth:stopSpeakingAtBoundary(0)
+	end
+	local utterance = objc.AVSpeechUtterance:alloc():initWithString(text)
+	backend.synth:speakUtterance(utterance)
 end
-local function isSpeaking()
-    if synth:isSpeaking()==1 then
-        return true
-    else
-        return false
-    end
+
+function backend.isSpeaking()
+	return backend.synth:isSpeaking()
 end
 
-return {output=output, isSpeaking=isSpeaking}
-
+return backend

--- a/macspeech.lua
+++ b/macspeech.lua
@@ -3,6 +3,8 @@ local objc = require("objc.objc")
 objc.load("AVFoundation")
 local backend = {}
 backend.synth = objc.AVSpeechSynthesizer:alloc():init()
+-- Because AVSpeechSynthesizer doesn't give us the proper default voice (it returned ALbert on my system for some reason), we have to do this bit of uglyness with NSSpeechSynthesizer.
+backend.voice = objc.NSSpeechSynthesizer:alloc():init():defaultVoice()
 
 function backend.output(text, interrupt)
 	text = tostring(text)
@@ -11,6 +13,7 @@ function backend.output(text, interrupt)
 		backend.synth:stopSpeakingAtBoundary(0)
 	end
 	local utterance = objc.AVSpeechUtterance:alloc():initWithString(text)
+	utterance.voice = objc.AVSpeechSynthesisVoice:voiceWithIdentifier(backend.voice)
 	backend.synth:speakUtterance(utterance)
 end
 


### PR DESCRIPTION
I've rewritten the MacOS output to use AVSpeechSynthesizer. From my 
testing, everything seems to work. The only annoying thing is that I had 
to use a function from NSSpeechSynthesizer to get the default voice, 
because it seems that functionality is broken in AVSpeechSynthesizer. Also 
worth noting that this locks us to MacOS 10.14 and above, as that's when 
AVSpeechSynthesizer was added. Probably a nonissue, but figured I'd 
mention it.
